### PR TITLE
RunQueries sometimes doesn't return results for all queries.

### DIFF
--- a/lib/sphinxapi.js
+++ b/lib/sphinxapi.js
@@ -748,17 +748,17 @@ SphinxClient.prototype.RunQueries = function (fn) {
 				}
 
 				var match = { 'id':doc, 'weight':weight, 'attrs':{} }
-				for (var i = 0; i < result['attrs'].length; i++) {
-					var attr0 = attrs[i][0]
-					if (attrs[i][1] == SphinxClient.SPH_ATTR_FLOAT) {
+				for (var j = 0;  < result['attrs'].length; j++) {
+					var attr0 = attrs[j][0]
+					if (attrs[j][1] == SphinxClient.SPH_ATTR_FLOAT) {
 						match['attrs'][attr0] = Number(unpack('>f', response.slice(p, p + 4)))
 					}
-					else if (attrs[i][1] == SphinxClient.SPH_ATTR_BIGINT) {
+					else if (attrs[j][1] == SphinxClient.SPH_ATTR_BIGINT) {
             //            match['attrs'][attr0] = Number(unpack('>q', response.slice(p, p + 8)))
             match['attrs'][attr0] = Number(unpackInt64(response.slice(p, p + 8)))
 						p += 4
 					}
-					else if (attrs[i][1] == SphinxClient.SPH_ATTR_STRING) {
+					else if (attrs[j][1] == SphinxClient.SPH_ATTR_STRING) {
 						var slen = Number(unpack('>L', response.slice(p, p + 4)))
 						p += 4
 						match['attrs'][attr0] = ''
@@ -767,7 +767,7 @@ SphinxClient.prototype.RunQueries = function (fn) {
 						}
 						p += slen-4
 					}
-					else if (attrs[i][1] == SphinxClient.SPH_ATTR_MULTI) {
+					else if (attrs[j][1] == SphinxClient.SPH_ATTR_MULTI) {
 						match['attrs'][attr0] = []
             var nvals = Number(unpack('>L', response.slice(p, p + 4)))
             p += 4
@@ -777,7 +777,7 @@ SphinxClient.prototype.RunQueries = function (fn) {
 						}
             p -= 4
 					}
-					else if (attrs[i][1] == SphinxClient.SPH_ATTR_MULTI64) {
+					else if (attrs[j][1] == SphinxClient.SPH_ATTR_MULTI64) {
 						match['attrs'][attr0] = []
 						nvals = Number(unpack('>L', response.slice(p, p + 4)))
 						nvals = nvals/2


### PR DESCRIPTION
Thanks very much for this project.  I will be using it a lot.

When handling the returned results in RunQueries there are nested for loops.
Both loops are using `i as the loop counter`.  Top for loop was exiting early if inner loop set i to a value greated then `nreqs`.

Just changed the inner loop to use `j` instead of `i`
