### PR TITLE
On RunQueries(), reset _reqs right after _SendRequest. Not on the callback.

### DIFF
--- a/lib/sphinxapi.js
+++ b/lib/sphinxapi.js
@@ -822,10 +822,11 @@ SphinxClient.prototype.RunQueries = function (fn) {
 				result['words'].push({'word':word, 'docs':docs, 'hits':hits})
 			}
 		}
-		self._reqs = []
 
 		fn(err, results)
 	})
+
+    this._reqs = []
 };
 SphinxClient.prototype.BuildExcerpts = function (docs, index, words, opts, cb) {
 	assert.equal(Array.isArray(docs), true);


### PR DESCRIPTION
If there are multiple `RunQueries()` calls before the first one have not been finished, `_reqs` remains and affects another calls.